### PR TITLE
fix: move PodcastPlayer to App shell so it persists across page navig…

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,6 +20,7 @@ import ExternalRedirect from "./pages/ExternalRedirect.tsx";
 import NotFound from "./pages/NotFound.tsx";
 
 import ScrollToTop from "./components/site/ScrollToTop.tsx";
+import PodcastPlayer from "./components/site/PodcastPlayer.tsx";
 import { PodcastProvider } from "./contexts/PodcastContext.tsx";
 
 const queryClient = new QueryClient();
@@ -32,6 +33,7 @@ const App = () => (
       <PodcastProvider>
       <BrowserRouter>
         <ScrollToTop />
+        <PodcastPlayer />
         <Routes>
           <Route path="/" element={<Index />} />
           <Route path="/team" element={<Team />} />

--- a/src/components/site/SiteLayout.tsx
+++ b/src/components/site/SiteLayout.tsx
@@ -1,7 +1,6 @@
 import { ReactNode } from "react";
 import Navbar from "./Navbar";
 import Footer from "./Footer";
-import PodcastPlayer from "./PodcastPlayer";
 
 import { SkipToMain } from "./SkipToMain";
 
@@ -13,7 +12,6 @@ export const SiteLayout = ({ children }: { children: ReactNode }) => (
       {children}
     </main>
     <Footer />
-    <PodcastPlayer />
   </div>
 );
 


### PR DESCRIPTION
…ations

SiteLayout was mounted per-page, causing PodcastPlayer to unmount/remount on every navigation. The prevIndex useRef reset to -1 on remount, making the effect think the index changed and re-speaking the current segment from the start.

PodcastPlayer now lives in App.tsx inside BrowserRouter but outside Routes, so it mounts once and never remounts during navigation.